### PR TITLE
fix: test timeouts due to sourcemap logic

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -81,7 +81,7 @@ export default class RelatedTestsConfig {
 
   private saveToDisk() {
     if (!fs.existsSync(CONFIG_FOLDER)) {
-      fs.mkdirSync(CONFIG_FOLDER);
+      fs.mkdirSync(CONFIG_FOLDER, { recursive: true });
     }
     fs.writeFileSync(CONFIG_FILE, JSON.stringify(this.config));
   }

--- a/src/connectors/local.ts
+++ b/src/connectors/local.ts
@@ -52,7 +52,7 @@ export class LocalFileSystemConnector extends LocalConnector {
 
   init() {
     if (!fs.existsSync(this.folder)) {
-      fs.mkdirSync(this.folder);
+      fs.mkdirSync(this.folder, { recursive: true });
     }
   }
 

--- a/src/extend/test.ts
+++ b/src/extend/test.ts
@@ -143,7 +143,7 @@ async function storeAffectedFiles(
 
   return Promise.all(
     coverage.map(async (entry) => {
-      if (entry.url.includes(rtcConfig.url)) {
+      if (!!rtcConfig.url && entry.url.includes(rtcConfig.url)) {
         if (!entry.source) {
           logger.warn(`${entry.url} has no source.`);
           return;


### PR DESCRIPTION
Fixes the sourcemaps logic. Since `rtcConfig.url` was initially set to `''`, the `entry.url.includes(rtcConfig.url)` would always return true.