### PR TITLE
feat: allow always run files

### DIFF
--- a/src/connectors/local.ts
+++ b/src/connectors/local.ts
@@ -64,6 +64,10 @@ export class LocalFileSystemConnector extends LocalConnector {
     return fs.readFileSync(path.join(this.folder, file), 'utf-8');
   }
 
+  exists(testName: string) {
+    return fs.existsSync(path.join(this.folder, `${testName}.json`));
+  }
+
   addRelationship(testName: string, fileName: string) {
     if (fileName.length === 0) return;
 

--- a/src/relationship/relationship-manager.spec.ts
+++ b/src/relationship/relationship-manager.spec.ts
@@ -9,6 +9,7 @@ describe('RelationshipManager', () => {
   const mockFiles = [
     'Component1~Component1.spec.ts Component1 shows basic component when hovering.json',
     'Component2~visual-regression~Component2.spec.ts Component2 Visual regression test - Component2 - Hover - component2-hover - dark.json',
+    'Component3~Component3.spec.ts Component3 shows basic component--always-run.json',
   ];
   const modifiedFiles = [
     'e2e/tests/vrt/Component1.spec.ts',
@@ -35,10 +36,12 @@ describe('RelationshipManager', () => {
     expect(impactedTestFiles).toStrictEqual([
       'Component1/Component1.spec.ts',
       'Component2/visual-regression/Component2.spec.ts',
+      'Component3/Component3.spec.ts',
     ]);
     expect(impactedTestNames).toStrictEqual([
       'Component1/Component1.spec.ts Component1 shows basic component when hovering',
       'Component2/visual-regression/Component2.spec.ts Component2 Visual regression test - Component2 - Hover - component2-hover - dark',
+      'Component3/Component3.spec.ts Component3 shows basic component',
     ]);
   });
 });

--- a/src/relationship/relationship-manager.ts
+++ b/src/relationship/relationship-manager.ts
@@ -71,17 +71,18 @@ export class RelationshipManager<T extends TRemoteConnector> {
       const affected = this.connectors.local.getFileContent(file);
       const affectedFiles: string[] = JSON.parse(affected);
 
+      const alwaysRun = file.includes('--always-run');
       const impacted = affectedFiles.some((f) =>
         this.modifiedFiles.includes(f),
       );
 
-      if (impacted) {
-        const fileName = file.replace('.json', '').split(' ')[0]!.trim();
+      if (impacted || alwaysRun) {
+        const cleanedFileName = file
+          .replace('--always-run', '')
+          .replace('.json', '');
+        const fileName = cleanedFileName.split(' ')[0]!.trim();
         const exactFileName = fileName.replaceAll('~', '/');
-        const exactTestName = file
-          .replace('.json', '')
-          .replace(fileName, '')
-          .trim();
+        const exactTestName = cleanedFileName.replace(fileName, '').trim();
 
         this.impactedTestFiles.add(exactFileName);
         this.impactedTestNames.add(`${exactFileName} ${exactTestName}`);


### PR DESCRIPTION
When running e2e, since this library relies on coverage, there might be tests that do not run in a chromium based browser, so there won't be coverage for those tests. Since these tests won't have any relationship with other files, they will always be skipped.

These changes force those tests to always be executed, so there are no problems of unexpected tests not being executed